### PR TITLE
ci: Bump dart version to 3.11

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dart
         uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
         with:
-          sdk: 3.7
+          sdk: 3.11
       - name: Get dependencies
         run: dart pub get
       - name: Check formatting

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dart
         uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
         with:
-          sdk: 3.7
+          sdk: 3.11
       - name: Install php
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:

--- a/.github/workflows/update_presets.yaml
+++ b/.github/workflows/update_presets.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dart
         uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
         with:
-          sdk: 3.7
+          sdk: 3.11
       - name: Update presets
         run: |
           dart pub get

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -232,4 +232,3 @@ linter:
     use_to_and_as_if_applicable: true
     valid_regexps: true
     void_checks: true
-    avoid_as: false


### PR DESCRIPTION
Currently latest version, but not unpinning to avoid unintended changes/failures when a new Dart version is released.