### PR TITLE
Refactor/migrate cookie store

### DIFF
--- a/packages/nextcloud_test/lib/src/fixture_interceptor.dart
+++ b/packages/nextcloud_test/lib/src/fixture_interceptor.dart
@@ -8,9 +8,7 @@ import 'package:interceptor_http_client/interceptor_http_client.dart';
 /// An http interceptor that records every request and adds them to a fixture.
 final class FixtureInterceptor implements HttpInterceptor {
   /// Creates a new fixture interceptor.
-  const FixtureInterceptor({
-    required this.appendFixture,
-  });
+  const FixtureInterceptor({required this.appendFixture});
 
   /// Callback for adding a recorded request to the fixture.
   final void Function(String fixture) appendFixture;
@@ -22,10 +20,7 @@ final class FixtureInterceptor implements HttpInterceptor {
 
   @override
   Future<http.BaseRequest> interceptRequest({required http.BaseRequest request}) async {
-    assert(
-      shouldInterceptRequest(request),
-      'Request should not be intercepted.',
-    );
+    assert(shouldInterceptRequest(request), 'Request should not be intercepted.');
 
     final bodyBytes = switch (request) {
       http.Request() => request.bodyBytes,
@@ -37,12 +32,13 @@ final class FixtureInterceptor implements HttpInterceptor {
 
     return switch (request) {
       http.Request() => request,
-      _ => http.Request(request.method, request.url)
-        ..persistentConnection = request.persistentConnection
-        ..followRedirects = request.followRedirects
-        ..maxRedirects = request.maxRedirects
-        ..headers.addAll(request.headers)
-        ..bodyBytes = bodyBytes,
+      _ =>
+        http.Request(request.method, request.url)
+          ..persistentConnection = request.persistentConnection
+          ..followRedirects = request.followRedirects
+          ..maxRedirects = request.maxRedirects
+          ..headers.addAll(request.headers)
+          ..bodyBytes = bodyBytes,
     };
   }
 

--- a/packages/nextcloud_test/lib/src/fixtures.dart
+++ b/packages/nextcloud_test/lib/src/fixtures.dart
@@ -61,11 +61,7 @@ void validateFixture(NextcloudTester tester) {
   final fixturesPath = PathUri(
     isAbsolute: false,
     isDirectory: true,
-    pathSegments: BuiltList.from([
-      'test',
-      'fixtures',
-      ...groups.map(_formatName),
-    ]),
+    pathSegments: BuiltList.from(['test', 'fixtures', ...groups.map(_formatName)]),
   );
   final fixturesDir = Directory(fixturesPath.path);
   if (!fixturesDir.existsSync()) {

--- a/packages/nextcloud_test/lib/src/matchers/webdav_props.dart
+++ b/packages/nextcloud_test/lib/src/matchers/webdav_props.dart
@@ -9,10 +9,7 @@ import 'package:test/test.dart';
 import 'package:xml/xml.dart';
 
 class _ContainsAllAvailableProps extends AsyncMatcher {
-  _ContainsAllAvailableProps(
-    this.tester,
-    this.uri,
-  );
+  _ContainsAllAvailableProps(this.tester, this.uri);
 
   final NextcloudTester tester;
   final PathUri uri;

--- a/packages/nextcloud_test/lib/src/models/nextcloud_tester.dart
+++ b/packages/nextcloud_test/lib/src/models/nextcloud_tester.dart
@@ -9,12 +9,9 @@ import 'package:version/version.dart';
 /// Class that manages the creation of nextcloud api clients and the test environment.
 final class NextcloudTester {
   /// Creates a new Nextcloud tester for the given [appName] and [version].
-  NextcloudTester({
-    required String appName,
-    required Version version,
-    String username = defaultTestUsername,
-  })  : _preset = (name: appName, version: version),
-        _username = username;
+  NextcloudTester({required String appName, required Version version, String username = defaultTestUsername})
+    : _preset = (name: appName, version: version),
+      _username = username;
 
   final Preset _preset;
 

--- a/packages/nextcloud_test/lib/src/presets.dart
+++ b/packages/nextcloud_test/lib/src/presets.dart
@@ -27,11 +27,7 @@ void presets(
   void innerBody() {
     for (final presetVersion in presets[presetGroup]) {
       group('${presetVersion.major}.${presetVersion.minor}', () {
-        final tester = NextcloudTester(
-          appName: presetGroup,
-          version: presetVersion,
-          username: username,
-        );
+        final tester = NextcloudTester(appName: presetGroup, version: presetVersion, username: username);
 
         setUpAll(() async {
           await tester.init();

--- a/packages/nextcloud_test/lib/src/test_target/docker_container.dart
+++ b/packages/nextcloud_test/lib/src/test_target/docker_container.dart
@@ -23,14 +23,7 @@ final class DockerContainerFactory extends TestTargetFactory<DockerContainerInst
     final dockerImageName =
         'ghcr.io/provokateurin/nextcloud.dart/dev:${preset.name}-${preset.version.major}.${preset.version.minor}';
 
-    var result = await runExecutableArguments(
-      'docker',
-      [
-        'images',
-        '-q',
-        dockerImageName,
-      ],
-    );
+    var result = await runExecutableArguments('docker', ['images', '-q', dockerImageName]);
     if (result.exitCode != 0) {
       throw Exception('Querying docker image failed: ${result.stderr}');
     }
@@ -43,20 +36,17 @@ final class DockerContainerFactory extends TestTargetFactory<DockerContainerInst
 
     while (true) {
       port = _randomPort();
-      result = await runExecutableArguments(
-        'docker',
-        [
-          'run',
-          '--rm',
-          '-d',
-          '--network',
-          'host',
-          dockerImageName,
-          'php',
-          '-S',
-          '0.0.0.0:$port',
-        ],
-      );
+      result = await runExecutableArguments('docker', [
+        'run',
+        '--rm',
+        '-d',
+        '--network',
+        'host',
+        dockerImageName,
+        'php',
+        '-S',
+        '0.0.0.0:$port',
+      ]);
       // The command will not fail if the port is already allocated since we run in detached mode.
       if (result.exitCode != 0) {
         throw Exception('Failed to run docker container: ${result.stderr}');
@@ -65,24 +55,13 @@ final class DockerContainerFactory extends TestTargetFactory<DockerContainerInst
       id = result.stdout.toString().replaceAll('\n', '');
 
       // Ensure container is still up and didn't crash because the port was already allocated.
-      result = await runExecutableArguments(
-        'docker',
-        [
-          'exec',
-          '-i',
-          id,
-          'true',
-        ],
-      );
+      result = await runExecutableArguments('docker', ['exec', '-i', id, 'true']);
       if (result.exitCode == 0) {
         break;
       }
     }
 
-    return DockerContainerInstance(
-      id: id,
-      port: port,
-    );
+    return DockerContainerInstance(id: id, port: port);
   }
 
   @override
@@ -91,10 +70,7 @@ final class DockerContainerFactory extends TestTargetFactory<DockerContainerInst
 
     return BuiltListMultimap<String, Version>.build((b) {
       for (final file in files) {
-        b.add(
-          p.split(file.dirname).last,
-          Version.parse(file.basename),
-        );
+        b.add(p.split(file.dirname).last, Version.parse(file.basename));
       }
     });
   }
@@ -104,10 +80,7 @@ final class DockerContainerFactory extends TestTargetFactory<DockerContainerInst
 @internal
 final class DockerContainerInstance extends TestTargetInstance {
   /// Creates a new Docker container instance.
-  DockerContainerInstance({
-    required this.id,
-    required this.port,
-  });
+  DockerContainerInstance({required this.id, required this.port});
 
   /// ID of the docker container.
   final String id;
@@ -117,38 +90,24 @@ final class DockerContainerInstance extends TestTargetInstance {
 
   /// Removes the docker container from the system.
   @override
-  Future<void> destroy() => runExecutableArguments(
-        'docker',
-        [
-          'kill',
-          id,
-        ],
-      );
+  Future<void> destroy() => runExecutableArguments('docker', ['kill', id]);
 
   @override
-  late Uri url = Uri(
-    scheme: 'http',
-    host: 'localhost',
-    port: port,
-  );
+  late Uri url = Uri(scheme: 'http', host: 'localhost', port: port);
 
   @override
   Future<String> createAppPassword(String username) async {
     final inputStream = StreamController<List<int>>();
-    final process = runExecutableArguments(
-      'docker',
-      [
-        'exec',
-        '-i',
-        id,
-        'php',
-        '-f',
-        'occ',
-        'user:add-app-password',
-        username,
-      ],
-      stdin: inputStream.stream,
-    );
+    final process = runExecutableArguments('docker', [
+      'exec',
+      '-i',
+      id,
+      'php',
+      '-f',
+      'occ',
+      'user:add-app-password',
+      username,
+    ], stdin: inputStream.stream);
     inputStream.add(utf8.encode(username));
     await inputStream.close();
 

--- a/packages/nextcloud_test/lib/src/test_target/local.dart
+++ b/packages/nextcloud_test/lib/src/test_target/local.dart
@@ -12,11 +12,7 @@ import 'package:version/version.dart';
 @internal
 final class LocalFactory extends TestTargetFactory<LocalInstance> {
   /// Creates a new test factory for a local server.
-  LocalFactory({
-    required String dir,
-    required Uri url,
-  })  : _dir = dir,
-        _instance = LocalInstance(url: url, dir: dir);
+  LocalFactory({required String dir, required Uri url}) : _dir = dir, _instance = LocalInstance(url: url, dir: dir);
 
   final String _dir;
 
@@ -30,16 +26,7 @@ final class LocalFactory extends TestTargetFactory<LocalInstance> {
     final presets = ListMultimapBuilder<String, Version>();
     final regex = RegExp('  - (.*): (.*)');
 
-    var result = runExecutableArgumentsSync(
-      'php',
-      [
-        '-f',
-        './occ',
-        'app:list',
-        '--enabled',
-      ],
-      workingDirectory: _dir,
-    );
+    var result = runExecutableArgumentsSync('php', ['-f', './occ', 'app:list', '--enabled'], workingDirectory: _dir);
     if (result.exitCode != 0) {
       throw Exception('Failed to list apps\n${result.stderr}\n${result.stdout}');
     }
@@ -54,15 +41,7 @@ final class LocalFactory extends TestTargetFactory<LocalInstance> {
       }
     }
 
-    result = runExecutableArgumentsSync(
-      'php',
-      [
-        '-f',
-        './occ',
-        'status',
-      ],
-      workingDirectory: _dir,
-    );
+    result = runExecutableArgumentsSync('php', ['-f', './occ', 'status'], workingDirectory: _dir);
     if (result.exitCode != 0) {
       throw Exception('Failed to get status\n${result.stderr}\n${result.stdout}');
     }
@@ -89,10 +68,7 @@ final class LocalFactory extends TestTargetFactory<LocalInstance> {
 @internal
 final class LocalInstance extends TestTargetInstance {
   /// Creates a new test instance for a local server.
-  LocalInstance({
-    required this.url,
-    required String dir,
-  }) : _dir = dir;
+  LocalInstance({required this.url, required String dir}) : _dir = dir;
 
   final String _dir;
 
@@ -107,12 +83,7 @@ final class LocalInstance extends TestTargetInstance {
     final inputStream = StreamController<List<int>>();
     final process = runExecutableArguments(
       'php',
-      [
-        '-f',
-        'occ',
-        'user:add-app-password',
-        username,
-      ],
+      ['-f', 'occ', 'user:add-app-password', username],
       stdin: inputStream.stream,
       workingDirectory: _dir,
     );

--- a/packages/nextcloud_test/lib/src/test_target/test_target.dart
+++ b/packages/nextcloud_test/lib/src/test_target/test_target.dart
@@ -27,10 +27,7 @@ abstract class TestTargetFactory<T extends TestTargetInstance> {
 
     if (url != null || dir != null) {
       // Fail hard if the variables are not properly set to avoid a fallback to docker.
-      return LocalFactory(
-        dir: dir!,
-        url: Uri.parse(url!),
-      );
+      return LocalFactory(dir: dir!, url: Uri.parse(url!));
     }
 
     return DockerContainerFactory();
@@ -64,9 +61,7 @@ abstract class TestTargetInstance {
   /// Creates a new [NextcloudClient] for a given [username].
   ///
   /// It is expected that the password of the user matches the its [username].
-  Future<NextcloudClient> createClient({
-    String? username = 'user1',
-  }) async {
+  Future<NextcloudClient> createClient({String? username = 'user1'}) async {
     String? appPassword;
     if (username != null) {
       appPassword = await createAppPassword(username);
@@ -75,9 +70,7 @@ abstract class TestTargetInstance {
     final httpClient = InterceptorHttpClient(
       baseClient: http.Client(),
       interceptors: BuiltList([
-        CookieStoreInterceptor(
-          cookieStore: CookieStore(),
-        ),
+        CookieStoreInterceptor(cookieStore: CookieStore()),
         const FixtureInterceptor(appendFixture: appendFixture),
       ]),
     );

--- a/packages/nextcloud_test/pubspec.yaml
+++ b/packages/nextcloud_test/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.9.0
 
 dependencies:
   built_collection: ^5.1.1

--- a/packages/nextcloud_test/pubspec.yaml
+++ b/packages/nextcloud_test/pubspec.yaml
@@ -11,16 +11,18 @@ dependencies:
   collection: ^1.0.0
   cookie_store:
     git:
-      url: https://github.com/nextcloud/neon
+      url: https://github.com/foldland/cookie_store
       path: packages/cookie_store
-      ref: 6ae0f81af522aedf0d0f8aa97ed90a3df395621f
+      tag_pattern: cookie_store-v{{version}}
+    version: ^0.1.0+1
   glob: ^2.1.2
   http: ^1.2.0
   interceptor_http_client:
     git:
-      url: https://github.com/nextcloud/neon
+      url: https://github.com/foldland/cookie_store
       path: packages/interceptor_http_client
-      ref: 6ae0f81af522aedf0d0f8aa97ed90a3df395621f
+      tag_pattern: interceptor_http_client-v{{version}}
+    version: ^0.1.0+1
   matcher: ^0.12.0
   meta: ^1.0.0
   nextcloud:


### PR DESCRIPTION
dart 3.9 is required to use the tag based imports.
I only bumped it in the test package for now.