### PR TITLE
Wip/update build toolchain

### DIFF
--- a/lib/src/api/core/core.openapi.g.dart
+++ b/lib/src/api/core/core.openapi.g.dart
@@ -19304,13 +19304,12 @@ class _$AutocompleteResult extends AutocompleteResult {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
     return other is AutocompleteResult &&
         id == other.id &&
         label == other.label &&
         icon == other.icon &&
         source == other.source &&
-        status == _$dynamicOther.status &&
+        status == other.status &&
         subline == other.subline &&
         shareWithDisplayNameUnique == other.shareWithDisplayNameUnique;
   }
@@ -34846,10 +34845,9 @@ class _$OcsGetCapabilitiesResponseApplicationJson_Ocs_Data extends OcsGetCapabil
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
     return other is OcsGetCapabilitiesResponseApplicationJson_Ocs_Data &&
         version == other.version &&
-        capabilities == _$dynamicOther.capabilities;
+        capabilities == other.capabilities;
   }
 
   @override
@@ -40642,16 +40640,15 @@ class _$TaskProcessingTaskType extends TaskProcessingTaskType {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
     return other is TaskProcessingTaskType &&
         name == other.name &&
         description == other.description &&
         inputShape == other.inputShape &&
         inputShapeEnumValues == other.inputShapeEnumValues &&
-        inputShapeDefaults == _$dynamicOther.inputShapeDefaults &&
+        inputShapeDefaults == other.inputShapeDefaults &&
         optionalInputShape == other.optionalInputShape &&
         optionalInputShapeEnumValues == other.optionalInputShapeEnumValues &&
-        optionalInputShapeDefaults == _$dynamicOther.optionalInputShapeDefaults &&
+        optionalInputShapeDefaults == other.optionalInputShapeDefaults &&
         outputShape == other.outputShape &&
         outputShapeEnumValues == other.outputShapeEnumValues &&
         optionalOutputShape == other.optionalOutputShape &&
@@ -41503,7 +41500,6 @@ class _$TaskProcessingTask extends TaskProcessingTask {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
     return other is TaskProcessingTask &&
         id == other.id &&
         lastUpdated == other.lastUpdated &&
@@ -41511,8 +41507,8 @@ class _$TaskProcessingTask extends TaskProcessingTask {
         status == other.status &&
         userId == other.userId &&
         appId == other.appId &&
-        input == _$dynamicOther.input &&
-        output == _$dynamicOther.output &&
+        input == other.input &&
+        output == other.output &&
         customId == other.customId &&
         completionExpectedAt == other.completionExpectedAt &&
         progress == other.progress &&
@@ -53385,12 +53381,11 @@ class _$UnifiedSearchResult extends UnifiedSearchResult {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
     return other is UnifiedSearchResult &&
         name == other.name &&
         isPaginated == other.isPaginated &&
         entries == other.entries &&
-        cursor == _$dynamicOther.cursor;
+        cursor == other.cursor;
   }
 
   @override

--- a/lib/src/api/provisioning_api/provisioning_api.openapi.g.dart
+++ b/lib/src/api/provisioning_api/provisioning_api.openapi.g.dart
@@ -9463,12 +9463,11 @@ class _$GroupDetails extends GroupDetails {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
     return other is GroupDetails &&
         id == other.id &&
         displayname == other.displayname &&
-        usercount == _$dynamicOther.usercount &&
-        disabled == _$dynamicOther.disabled &&
+        usercount == other.usercount &&
+        disabled == other.disabled &&
         canAdd == other.canAdd &&
         canRemove == other.canRemove;
   }
@@ -10401,10 +10400,9 @@ class _$UserDetailsQuota extends UserDetailsQuota {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
     return other is UserDetailsQuota &&
         free == other.free &&
-        quota == _$dynamicOther.quota &&
+        quota == other.quota &&
         relative == other.relative &&
         total == other.total &&
         used == other.used;
@@ -11411,8 +11409,7 @@ class _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
-    return other is GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data && users == _$dynamicOther.users;
+    return other is GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data && users == other.users;
   }
 
   @override
@@ -12989,8 +12986,7 @@ class _$UsersGetLastLoggedInUsersResponseApplicationJson_Ocs_Data
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
-    return other is UsersGetLastLoggedInUsersResponseApplicationJson_Ocs_Data && users == _$dynamicOther.users;
+    return other is UsersGetLastLoggedInUsersResponseApplicationJson_Ocs_Data && users == other.users;
   }
 
   @override
@@ -15082,8 +15078,7 @@ class _$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
-    return other is UsersGetUsersDetailsResponseApplicationJson_Ocs_Data && users == _$dynamicOther.users;
+    return other is UsersGetUsersDetailsResponseApplicationJson_Ocs_Data && users == other.users;
   }
 
   @override
@@ -15520,8 +15515,7 @@ class _$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
-    return other is UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data && users == _$dynamicOther.users;
+    return other is UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data && users == other.users;
   }
 
   @override

--- a/lib/src/api/settings/settings.openapi.g.dart
+++ b/lib/src/api/settings/settings.openapi.g.dart
@@ -1426,7 +1426,6 @@ class _$DeclarativeFormField extends DeclarativeFormField {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
     return other is DeclarativeFormField &&
         id == other.id &&
         title == other.title &&
@@ -1435,8 +1434,8 @@ class _$DeclarativeFormField extends DeclarativeFormField {
         placeholder == other.placeholder &&
         label == other.label &&
         $default == other.$default &&
-        options == _$dynamicOther.options &&
-        value == _$dynamicOther.value;
+        options == other.options &&
+        value == other.value;
   }
 
   @override

--- a/lib/src/api/spreed/spreed.openapi.g.dart
+++ b/lib/src/api/spreed/spreed.openapi.g.dart
@@ -28441,7 +28441,6 @@ class _$Room extends Room {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
     return other is Room &&
         actorId == other.actorId &&
         invitedActorId == other.invitedActorId &&
@@ -28470,7 +28469,7 @@ class _$Room extends Room {
         isFavorite == other.isFavorite &&
         lastActivity == other.lastActivity &&
         lastCommonReadMessage == other.lastCommonReadMessage &&
-        lastMessage == _$dynamicOther.lastMessage &&
+        lastMessage == other.lastMessage &&
         lastPing == other.lastPing &&
         lastReadMessage == other.lastReadMessage &&
         listable == other.listable &&
@@ -39361,9 +39360,8 @@ class _$ChatMessageWithParent extends ChatMessageWithParent {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
     return other is ChatMessageWithParent &&
-        parent == _$dynamicOther.parent &&
+        parent == other.parent &&
         deleted == other.deleted &&
         id == other.id &&
         isReplyable == other.isReplyable &&
@@ -46781,9 +46779,8 @@ class _$SignalingSettings extends SignalingSettings {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
     return other is SignalingSettings &&
-        federation == _$dynamicOther.federation &&
+        federation == other.federation &&
         helloAuthParams == other.helloAuthParams &&
         hideWarning == other.hideWarning &&
         server == other.server &&
@@ -50214,10 +50211,7 @@ class _$SignalingPullMessagesResponseApplicationJson_Ocs_Data
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
-    return other is SignalingPullMessagesResponseApplicationJson_Ocs_Data &&
-        type == other.type &&
-        data == _$dynamicOther.data;
+    return other is SignalingPullMessagesResponseApplicationJson_Ocs_Data && type == other.type && data == other.data;
   }
 
   @override
@@ -70731,10 +70725,7 @@ class _$RoomSetMessageExpirationResponseApplicationJson_Ocs
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
-    return other is RoomSetMessageExpirationResponseApplicationJson_Ocs &&
-        meta == other.meta &&
-        data == _$dynamicOther.data;
+    return other is RoomSetMessageExpirationResponseApplicationJson_Ocs && meta == other.meta && data == other.data;
   }
 
   @override
@@ -72580,8 +72571,7 @@ class _$RoomGetCapabilitiesResponseApplicationJson_Ocs extends RoomGetCapabiliti
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
-    return other is RoomGetCapabilitiesResponseApplicationJson_Ocs && meta == other.meta && data == _$dynamicOther.data;
+    return other is RoomGetCapabilitiesResponseApplicationJson_Ocs && meta == other.meta && data == other.data;
   }
 
   @override
@@ -77079,8 +77069,7 @@ class _$SettingsSetUserSettingRequestApplicationJson extends SettingsSetUserSett
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
-    return other is SettingsSetUserSettingRequestApplicationJson && key == other.key && value == _$dynamicOther.value;
+    return other is SettingsSetUserSettingRequestApplicationJson && key == other.key && value == other.value;
   }
 
   @override
@@ -80993,7 +80982,6 @@ class _$RoomWithInvalidInvitations extends RoomWithInvalidInvitations {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
     return other is RoomWithInvalidInvitations &&
         invalidParticipants == other.invalidParticipants &&
         actorId == other.actorId &&
@@ -81023,7 +81011,7 @@ class _$RoomWithInvalidInvitations extends RoomWithInvalidInvitations {
         isFavorite == other.isFavorite &&
         lastActivity == other.lastActivity &&
         lastCommonReadMessage == other.lastCommonReadMessage &&
-        lastMessage == _$dynamicOther.lastMessage &&
+        lastMessage == other.lastMessage &&
         lastPing == other.lastPing &&
         lastReadMessage == other.lastReadMessage &&
         listable == other.listable &&

--- a/lib/src/api/tables/tables.openapi.g.dart
+++ b/lib/src/api/tables/tables.openapi.g.dart
@@ -8062,11 +8062,7 @@ class _$View_Filter extends View_Filter {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
-    return other is View_Filter &&
-        columnId == other.columnId &&
-        $operator == other.$operator &&
-        value == _$dynamicOther.value;
+    return other is View_Filter && columnId == other.columnId && $operator == other.$operator && value == other.value;
   }
 
   @override
@@ -9979,11 +9975,10 @@ class _$Api1UpdateViewRequestApplicationJson_Data3_Value extends Api1UpdateViewR
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
     return other is Api1UpdateViewRequestApplicationJson_Data3_Value &&
         columnId == other.columnId &&
         $operator == other.$operator &&
-        value == _$dynamicOther.value;
+        value == other.value;
   }
 
   @override
@@ -10217,8 +10212,7 @@ class _$Api1UpdateViewRequestApplicationJson extends Api1UpdateViewRequestApplic
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
-    return other is Api1UpdateViewRequestApplicationJson && data == _$dynamicOther.data;
+    return other is Api1UpdateViewRequestApplicationJson && data == other.data;
   }
 
   @override
@@ -13572,8 +13566,7 @@ class _$Api1CreateRowInTableRequestApplicationJson extends Api1CreateRowInTableR
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
-    return other is Api1CreateRowInTableRequestApplicationJson && data == _$dynamicOther.data;
+    return other is Api1CreateRowInTableRequestApplicationJson && data == other.data;
   }
 
   @override
@@ -13665,8 +13658,7 @@ class _$Api1CreateRowInViewRequestApplicationJson extends Api1CreateRowInViewReq
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
-    return other is Api1CreateRowInViewRequestApplicationJson && data == _$dynamicOther.data;
+    return other is Api1CreateRowInViewRequestApplicationJson && data == other.data;
   }
 
   @override
@@ -13760,8 +13752,7 @@ class _$Api1UpdateRowRequestApplicationJson extends Api1UpdateRowRequestApplicat
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
-    return other is Api1UpdateRowRequestApplicationJson && viewId == other.viewId && data == _$dynamicOther.data;
+    return other is Api1UpdateRowRequestApplicationJson && viewId == other.viewId && data == other.data;
   }
 
   @override
@@ -23088,8 +23079,7 @@ class _$RowocsCreateRowRequestApplicationJson extends RowocsCreateRowRequestAppl
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
-    return other is RowocsCreateRowRequestApplicationJson && data == _$dynamicOther.data;
+    return other is RowocsCreateRowRequestApplicationJson && data == other.data;
   }
 
   @override

--- a/lib/src/api/user_status/user_status.openapi.g.dart
+++ b/lib/src/api/user_status/user_status.openapi.g.dart
@@ -2504,8 +2504,7 @@ class _$ClearAt extends ClearAt {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
-    return other is ClearAt && type == other.type && time == _$dynamicOther.time;
+    return other is ClearAt && type == other.type && time == other.time;
   }
 
   @override
@@ -4906,10 +4905,7 @@ class _$UserStatusRevertStatusResponseApplicationJson_Ocs extends UserStatusReve
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
-    return other is UserStatusRevertStatusResponseApplicationJson_Ocs &&
-        meta == other.meta &&
-        data == _$dynamicOther.data;
+    return other is UserStatusRevertStatusResponseApplicationJson_Ocs && meta == other.meta && data == other.data;
   }
 
   @override

--- a/lib/src/api/weather_status/weather_status.openapi.g.dart
+++ b/lib/src/api/weather_status/weather_status.openapi.g.dart
@@ -5313,10 +5313,7 @@ class _$WeatherStatusGetForecastResponseApplicationJson_Ocs
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
-    return other is WeatherStatusGetForecastResponseApplicationJson_Ocs &&
-        meta == other.meta &&
-        data == _$dynamicOther.data;
+    return other is WeatherStatusGetForecastResponseApplicationJson_Ocs && meta == other.meta && data == other.data;
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,8 +34,8 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.5.4
-  built_value_generator: ^8.10.1
-  built_value_test: ^8.10.1
+  built_value_generator: ^8.12.5
+  built_value_test: ^8.12.5
   code_builder: ^4.11.1
   dart_style: ^3.1.8
   dynamite: ^0.6.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   xml_annotation: ^2.4.0
 
 dev_dependencies:
-  build_runner: ^2.5.4
+  build_runner: ^2.13.1
   built_value_generator: ^8.12.5
   built_value_test: ^8.12.5
   code_builder: ^4.11.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,7 @@ dev_dependencies:
   built_value_generator: ^8.10.1
   built_value_test: ^8.10.1
   code_builder: ^4.11.1
-  dart_style: ^3.1.0
+  dart_style: ^3.1.8
   dynamite: ^0.6.0
   glob: ^2.1.3
   http_client_conformance_tests:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,3 +61,17 @@ platforms:
   android:
   ios:
   web:
+
+dependency_overrides:
+  xml_serializable:
+    git:
+      url: https://github.com/tnc1997/dart-xml-serializable
+      path: xml_serializable
+      ref: ff28c57bb0d722a2b170d086aa85ce2eab4c18f0
+  xml_annotation:
+    git:
+      url: https://github.com/tnc1997/dart-xml-serializable
+      path: xml_annotation
+      ref: ff28c57bb0d722a2b170d086aa85ce2eab4c18f0
+  build: ">=3.0.0 <5.0.0"
+  dart_style: ^3.0.0


### PR DESCRIPTION
This is a POC that bumps xml_serializable (https://github.com/tnc1997/dart-xml-serializable/issues/66) and the entire build toolchain (#8 #9 #3).

I had to manually bump package:build because dynamite does not yet offer support for version 3.0 or higher.
It looks like dynamite is not affected by these changes and we only get a diff from the updated built_value package.

I'll report my findings to the xml_serializable project so we can hopefully get a hosted release soon.